### PR TITLE
feat: add delete experiment route

### DIFF
--- a/request.http
+++ b/request.http
@@ -60,6 +60,13 @@ Authorization: bearer {{jwt_token}}
 
 ###
 
-GET http://{{hostname}}/experiment/62bf0ef51ff25598aafa3e66
+GET http://{{hostname}}/experiment/62bb13dfea2b3ea78771e305
+Content-Type: application/json
+Authorization: bearer {{jwt_token}}
+
+
+### 
+
+DELETE http://{{hostname}}/experiment/62bf0ef51ff25598aafa3e66
 Content-Type: application/json
 Authorization: bearer {{jwt_token}}

--- a/src/handler/experiment_delete.rs
+++ b/src/handler/experiment_delete.rs
@@ -1,0 +1,76 @@
+use actix_web::{web, web::Json, HttpMessage, HttpRequest};
+use serde::{Deserialize, Serialize};
+
+use super::{Claims, CustomAPIError, HandlerError};
+use crate::service::experiment as experiment_service;
+use crate::Dependency;
+
+#[derive(Deserialize)]
+pub struct Params {
+    pub id: String,
+}
+
+#[derive(Serialize)]
+pub struct ResponsePayload {
+    acknowledge: bool,
+}
+
+/// Handle function to handle delete experimental request.
+pub async fn handle<ER: experiment_service::Store>(
+    req: HttpRequest,
+    path: web::Path<Params>,
+    dep: web::Data<Dependency<ER>>,
+) -> Result<Json<ResponsePayload>, CustomAPIError> {
+    let experiment_repo = &dep.experiment_repo;
+    let params = path.into_inner();
+
+    let channel_id: String;
+    if let Some(ut) = req.extensions().get::<Claims>() {
+        channel_id = ut.channel_id.clone();
+    } else {
+        return Err(HandlerError::Unauthorize.into());
+    }
+
+    let data = experiment_service::delete(experiment_repo, &params.id, &channel_id).await;
+
+    match data {
+        Ok(data) => Ok(Json(ResponsePayload { acknowledge: true })),
+        Err(e) => Err(e.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::experiment as experiment_service;
+    use crate::Dependency;
+    use anyhow::Ok;
+
+    use actix_web::{http::header::ContentType, test};
+
+    #[actix_web::test]
+    async fn test_handler_ok() {
+        let mut mock_store = experiment_service::MockStore::new();
+        let mock_delete_result = Ok(());
+        mock_store
+            .expect_delete()
+            .return_once(move |_, _| mock_delete_result);
+
+        let data = web::Data::new(Dependency {
+            experiment_repo: mock_store,
+        });
+
+        let mock_claims = Claims::default();
+        let req = test::TestRequest::default()
+            .insert_header(ContentType::json())
+            .to_http_request();
+        req.extensions_mut().insert(mock_claims);
+
+        let params = web::Path::from(Params {
+            id: "aaa".to_owned(),
+        });
+
+        let resp = handle(req, params, data).await;
+        assert!(resp.is_ok());
+    }
+}

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -15,6 +15,7 @@ use crate::middleware::auth;
 use crate::service::experiment;
 
 pub mod experiment_create;
+pub mod experiment_delete;
 pub mod experiment_get;
 pub mod experiment_list;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,8 @@ where
                         conf.jwt_secret.clone(),
                         Claims::default(),
                     ))
-                    .route(web::get().to(handler::experiment_get::handle::<ExpStore>)),
+                    .route(web::get().to(handler::experiment_get::handle::<ExpStore>))
+                    .route(web::delete().to(handler::experiment_delete::handle::<ExpStore>)),
             )
             .service(
                 web::resource("/experiments")

--- a/src/service/experiment.rs
+++ b/src/service/experiment.rs
@@ -112,6 +112,7 @@ pub trait Store {
     async fn save(&self, data: &mut Experiment) -> Result<String>;
     async fn list(&self, channel_id: &str) -> Result<Vec<Experiment>>;
     async fn get(&self, id: &str, channel_id: &str) -> Result<Experiment>;
+    async fn delete(&self, id: &str, channel_id: &str) -> Result<()>;
 }
 
 ///
@@ -153,4 +154,8 @@ pub async fn get(repo: &impl Store, id: &str, channel_id: &str) -> Result<Experi
         Ok(experiment) => Ok(experiment),
         Err(err) => Err(err),
     }
+}
+
+pub async fn delete(repo: &impl Store, id: &str, channel_id: &str) -> Result<()> {
+    repo.delete(id, channel_id).await
 }


### PR DESCRIPTION
# Changes
- Add API endpoint for deletes the experiment data by id.
- Add service function `delete`
- Add repository function `delete`
- Add request.http example request to `delete` endpoint.

